### PR TITLE
467 member images endpoint

### DIFF
--- a/djconnectwise/api.py
+++ b/djconnectwise/api.py
@@ -471,7 +471,7 @@ class SystemAPIClient(ConnectWiseAPIClient):
 
     # endpoints
     ENDPOINT_MEMBERS = 'members/'
-    ENDPOINT_MEMBERS_IMAGE = 'members/{}/image'
+    ENDPOINT_MEMBERS_IMAGE = 'documents/{}/download'
     ENDPOINT_MEMBERS_COUNT = 'members/count'
     ENDPOINT_CALLBACKS = 'callbacks/'
     ENDPOINT_INFO = 'info/'
@@ -557,13 +557,13 @@ class SystemAPIClient(ConnectWiseAPIClient):
     def get_member_by_identifier(self, identifier):
         return self.fetch_resource('members/{0}'.format(identifier))
 
-    def get_member_image_by_identifier(self, identifier):
+    def get_member_image_by_photo_id(self, photo_id, username):
         """
         Return a (filename, content) tuple.
         """
         try:
             endpoint = self._endpoint(
-                self.ENDPOINT_MEMBERS_IMAGE.format(identifier)
+                self.ENDPOINT_MEMBERS_IMAGE.format(photo_id)
             )
             logger.debug('Making GET request to {}'.format(endpoint))
             response = requests.get(
@@ -580,10 +580,10 @@ class SystemAPIClient(ConnectWiseAPIClient):
             content_disposition_header = headers.get('Content-Disposition',
                                                      default='')
             msg = "Got member '{}' image; size {} bytes " \
-                "and content-disposition header '{}'"
+                  "and content-disposition header '{}'"
 
             logger.info(msg.format(
-                identifier,
+                username,
                 len(response.content),
                 content_disposition_header
             ))

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -169,6 +169,8 @@ class Member(TimeStampedModel):
     last_name = models.CharField(max_length=30, blank=False)
     office_email = models.EmailField(max_length=250)
     inactive = models.BooleanField(default=False)
+    # CW 2017.6 (or thereabouts) removed the image endpoint and now has 'photo'
+    # as a Member field. We will sync and call it the avatar.
     avatar = ThumbnailerImageField(
         null=True, blank=True,
         verbose_name=_('Member Avatar'), help_text=_('Member Avatar')

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -803,22 +803,18 @@ class MemberSynchronizer(Synchronizer):
         if self.last_sync_job_time:
             member_stale = member_last_updated > self.last_sync_job_time
 
-        try:
-            if api_instance.get('photo'):
-                photo_id = api_instance['photo']['id']
-            if (not self.last_sync_job_time or member_stale or created) \
-                    and photo_id:
-                logger.info(
-                    'Fetching avatar for member {}.'.format(username)
-                )
-                (attachment_filename, avatar) = self.client \
-                    .get_member_image_by_photo_id(photo_id, username)
-                if attachment_filename and avatar:
-                    self._save_avatar(instance, avatar, attachment_filename)
-                    instance.save()
-
-        except Exception as e:
-            print('photo not assigned to {}: {}'.format(username, e.__cause__))
+        if api_instance.get('photo'):
+            photo_id = api_instance['photo']['id']
+        if (not self.last_sync_job_time or member_stale or created) \
+                and photo_id:
+            logger.info(
+                'Fetching avatar for member {}.'.format(username)
+            )
+            (attachment_filename, avatar) = self.client \
+                .get_member_image_by_photo_id(photo_id, username)
+            if attachment_filename and avatar:
+                self._save_avatar(instance, avatar, attachment_filename)
+                instance.save()
 
         return instance, created
 

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -794,8 +794,7 @@ class MemberSynchronizer(Synchronizer):
         """
         instance, created = super().update_or_create_instance(api_instance)
         username = instance.identifier
-        if api_instance.get('photo'):
-            photo_id = api_instance['photo']['id']
+        photo_id = None
 
         # Only update the avatar if the member profile
         # was updated since last sync.
@@ -804,15 +803,22 @@ class MemberSynchronizer(Synchronizer):
         if self.last_sync_job_time:
             member_stale = member_last_updated > self.last_sync_job_time
 
-        if not self.last_sync_job_time or member_stale or created:
-            logger.info(
-                'Fetching avatar for member {}.'.format(username)
-            )
-            (attachment_filename, avatar) = self.client \
-                .get_member_image_by_photo_id(photo_id, username)
-            if attachment_filename and avatar:
-                self._save_avatar(instance, avatar, attachment_filename)
-                instance.save()
+        try:
+            if api_instance.get('photo'):
+                photo_id = api_instance['photo']['id']
+            if (not self.last_sync_job_time or member_stale or created) \
+                    and photo_id:
+                logger.info(
+                    'Fetching avatar for member {}.'.format(username)
+                )
+                (attachment_filename, avatar) = self.client \
+                    .get_member_image_by_photo_id(photo_id, username)
+                if attachment_filename and avatar:
+                    self._save_avatar(instance, avatar, attachment_filename)
+                    instance.save()
+
+        except Exception as e:
+            print('photo not assigned to {}: {}'.format(username, e.__cause__))
 
         return instance, created
 

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -794,6 +794,8 @@ class MemberSynchronizer(Synchronizer):
         """
         instance, created = super().update_or_create_instance(api_instance)
         username = instance.identifier
+        if api_instance.get('photo'):
+            photo_id = api_instance['photo']['id']
 
         # Only update the avatar if the member profile
         # was updated since last sync.
@@ -807,7 +809,7 @@ class MemberSynchronizer(Synchronizer):
                 'Fetching avatar for member {}.'.format(username)
             )
             (attachment_filename, avatar) = self.client \
-                .get_member_image_by_identifier(username)
+                .get_member_image_by_photo_id(photo_id, username)
             if attachment_filename and avatar:
                 self._save_avatar(instance, avatar, attachment_filename)
                 instance.save()

--- a/djconnectwise/tests/fixtures.py
+++ b/djconnectwise/tests/fixtures.py
@@ -301,6 +301,15 @@ API_MEMBER = {
     'officeEmail': 'test@test.com',
     'officeExtension': None,
     'officePhone': '555-121-2121',
+    'photo': {
+        'id': 267,
+        'name': 'pexels-photo-119705-square-resized.jpg',
+        '_info': {
+            'filename': 'pexels-photo-119705-square-resized.jpg',
+            'document_href': 'https://connectwise.kerkhofftech.ca/v4_6_release/apis/3.0/system/documents/267',
+            'documentDownload_href': 'https://connectwise.kerkhofftech.ca/v4_6_release/apis/3.0/system/documents/267/download'
+        }
+    },
     'projectDefaultBoard': None,
     'projectDefaultDepartmentId': None,
     'projectDefaultLocationId': None,
@@ -373,8 +382,6 @@ API_MEMBER = {
     '_info': {
         'lastUpdated': '2015-08-24T19:50:10Z',
         'updatedBy': 'User1',
-        'image_href': 'https://some-host.com/v4_6_release/apis/3.0/' +
-        'system/members/176/image?lastModified=2015-08-24T19:50:10Z'
     }
 }
 

--- a/djconnectwise/tests/mocks.py
+++ b/djconnectwise/tests/mocks.py
@@ -179,7 +179,7 @@ def system_api_get_members_call(return_value):
 
 def system_api_get_member_image_by_identifier_call(return_value):
     method_name = 'djconnectwise.api.SystemAPIClient.' \
-                  + 'get_member_image_by_identifier'
+                  + 'get_member_image_by_photo_id'
 
     return create_mock_call(method_name, return_value)
 

--- a/djconnectwise/tests/mocks.py
+++ b/djconnectwise/tests/mocks.py
@@ -177,7 +177,7 @@ def system_api_get_members_call(return_value):
     return create_mock_call(method_name, return_value)
 
 
-def system_api_get_member_image_by_identifier_call(return_value):
+def system_api_get_member_image_by_photo_id_call(return_value):
     method_name = 'djconnectwise.api.SystemAPIClient.' \
                   + 'get_member_image_by_photo_id'
 

--- a/djconnectwise/tests/test_api.py
+++ b/djconnectwise/tests/test_api.py
@@ -190,13 +190,14 @@ class TestSystemAPIClient(BaseAPITestCase):
         self.assert_request_should_page(True)
 
     @responses.activate
-    def test_get_member_image_by_identifier(self):
+    def test_get_member_image_by_photo_id(self):
         member = fixtures.API_MEMBER
         # Requests will fake returning this as the filename
         avatar = mk.get_member_avatar()
         avatar_filename = 'AnonymousMember.png'
         endpoint = self.client._endpoint(
-            self.client.ENDPOINT_MEMBERS_IMAGE.format(member['identifier']))
+            self.client.ENDPOINT_MEMBERS_IMAGE.format(member['photo']['id'],
+                                                      member['identifier']))
         mk.get_raw(
             endpoint,
             avatar,
@@ -207,7 +208,8 @@ class TestSystemAPIClient(BaseAPITestCase):
         )
 
         result_filename, result_avatar = self.client \
-            .get_member_image_by_photo_id(member['identifier'])
+            .get_member_image_by_photo_id(member['photo']['id'],
+                                          member['identifier'])
 
         self.assertEqual(result_filename, avatar_filename)
         self.assertEqual(result_avatar, avatar)

--- a/djconnectwise/tests/test_api.py
+++ b/djconnectwise/tests/test_api.py
@@ -207,7 +207,7 @@ class TestSystemAPIClient(BaseAPITestCase):
         )
 
         result_filename, result_avatar = self.client \
-            .get_member_image_by_identifier(member['identifier'])
+            .get_member_image_by_photo_id(member['identifier'])
 
         self.assertEqual(result_filename, avatar_filename)
         self.assertEqual(result_avatar, avatar)

--- a/djconnectwise/tests/test_commands.py
+++ b/djconnectwise/tests/test_commands.py
@@ -221,7 +221,7 @@ class TestSyncActivityCommand(AbstractBaseSyncTest, TestCase):
     def setUp(self):
         super(). setUp()
         fixture_utils.init_companies()
-        mocks.system_api_get_member_image_by_identifier_call(
+        mocks.system_api_get_member_image_by_photo_id_call(
             (mocks.CW_MEMBER_IMAGE_FILENAME, mocks.get_member_avatar()))
         fixture_utils.init_members()
         fixture_utils.init_opportunity_statuses()
@@ -237,7 +237,7 @@ class TestSyncAllCommand(TestCase):
     def setUp(self):
         super().setUp()
         mocks.system_api_get_members_call([fixtures.API_MEMBER])
-        mocks.system_api_get_member_image_by_identifier_call(
+        mocks.system_api_get_member_image_by_photo_id_call(
             (mocks.CW_MEMBER_IMAGE_FILENAME, mocks.get_member_avatar()))
         mocks.company_api_by_id_call(fixtures.API_COMPANY)
         mocks.service_api_tickets_call()

--- a/djconnectwise/tests/test_sync.py
+++ b/djconnectwise/tests/test_sync.py
@@ -383,7 +383,7 @@ class TestMemberSynchronization(TestCase):
         self.identifier = 'User1'
         self.synchronizer = sync.MemberSynchronizer()
         mocks.system_api_get_members_call([fixtures.API_MEMBER])
-        mocks.system_api_get_member_image_by_identifier_call(
+        mocks.system_api_get_member_image_by_photo_id_call(
             (mocks.CW_MEMBER_IMAGE_FILENAME, mocks.get_member_avatar()))
 
     def _assert_member_fields(self, local_member, api_member):
@@ -416,6 +416,15 @@ class TestMemberSynchronization(TestCase):
         api_member = fixtures.API_MEMBER
         self._assert_member_fields(local_member, api_member)
         assert_sync_job(Member)
+
+    def test_sync_member_with_no_photo(self):
+        local_member = Member.objects.all().first()
+        api_member = fixtures.API_MEMBER
+        api_member.pop('photo')
+        self.synchronizer.sync()
+        self._assert_member_fields(local_member, api_member)
+        local_avatar = local_member.avatar
+        self.assertFalse(local_avatar)
 
 
 class TestOpportunitySynchronizer(TestCase, SynchronizerTestMixin):
@@ -554,7 +563,7 @@ class TestTicketSynchronizer(TestCase):
     def setUp(self):
         super().setUp()
         mocks.system_api_get_members_call(fixtures.API_MEMBER_LIST)
-        mocks.system_api_get_member_image_by_identifier_call(
+        mocks.system_api_get_member_image_by_photo_id_call(
             (mocks.CW_MEMBER_IMAGE_FILENAME, mocks.get_member_avatar()))
         mocks.service_api_tickets_call()
 


### PR DESCRIPTION
ConnectWise 2017.6 (or thereabouts) changed the REST location of member images from `members/{}/image` to a `photo` field on the Member object.  This pull request updates that change in djconnectwise.
Also, for the new location of member photos, a new permission is required:

Companies => Manage Documents => Inquire Level: All

