### PR TITLE
475 download member avatars on a full sync

### DIFF
--- a/djconnectwise/management/commands/cwsync.py
+++ b/djconnectwise/management/commands/cwsync.py
@@ -58,16 +58,15 @@ class Command(BaseCommand):
                             dest='full',
                             default=False)
 
-    def sync_by_class(self, sync_class, obj_name, full=False):
-        synchronizer = sync_class()
+    def sync_by_class(self, sync_class, obj_name, full_option=False):
+        synchronizer = sync_class(full=full_option)
 
-        created_count, updated_count, deleted_count = synchronizer.sync(
-            full=full)
+        created_count, updated_count, deleted_count = synchronizer.sync()
 
         msg = _('{} Sync Summary - Created: {}, Updated: {}')
         fmt_msg = msg.format(obj_name, created_count, updated_count)
 
-        if full:
+        if full_option:
             msg = _('{} Sync Summary - Created: {}, Updated: {}, Deleted: {}')
             fmt_msg = msg.format(obj_name, created_count, updated_count,
                                  deleted_count)
@@ -107,7 +106,8 @@ class Command(BaseCommand):
 
         for sync_class, obj_name in sync_classes:
             try:
-                self.sync_by_class(sync_class, obj_name, full=full_option)
+                self.sync_by_class(sync_class, obj_name,
+                                   full_option=full_option)
 
             except api.ConnectWiseAPIError as e:
                 msg = 'Failed to sync {}: {}'.format(obj_name, e)

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -69,11 +69,12 @@ class SyncResults:
 class Synchronizer:
     lookup_key = 'id'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, full=False, *args, **kwargs):
         self.api_conditions = []
         self.client = self.client_class()
         request_settings = RequestSettings().get_settings()
         self.batch_size = request_settings['batch_size']
+        self.full = full
 
     @staticmethod
     def _assign_null_relation(instance, model_field):
@@ -237,12 +238,12 @@ class Synchronizer:
         return deleted_count
 
     @log_sync_job
-    def sync(self, full=False):
+    def sync(self):
         sync_job_qset = models.SyncJob.objects.filter(
             entity_name=self.model_class.__name__
         )
 
-        if sync_job_qset.exists() and not full:
+        if sync_job_qset.exists() and not self.full:
             last_sync_job_time = sync_job_qset.last().start_time.isoformat()
             self.api_conditions.append(
                 "lastUpdated>[{0}]".format(last_sync_job_time)
@@ -250,9 +251,9 @@ class Synchronizer:
         results = SyncResults()
         initial_ids = self._instance_ids()  # Set of IDs of all records prior
         # to sync, to find stale records for deletion.
-        results = self.get(results)
+        results = self.get(results, )
 
-        if full:
+        if self.full:
             results.deleted_count = self.prune_stale_records(
                 initial_ids, results.synced_ids
             )
@@ -375,9 +376,9 @@ class BoardStatusSynchronizer(BoardChildSynchronizer):
     client_class = api.ServiceAPIClient
     model_class = models.BoardStatus
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.api_conditions = ['inactive=False']
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def _assign_field_data(self, instance, json_data):
         instance = super(BoardStatusSynchronizer, self)._assign_field_data(
@@ -422,9 +423,9 @@ class CompanySynchronizer(Synchronizer):
     client_class = api.CompanyAPIClient
     model_class = models.Company
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.api_conditions = ['deletedFlag=False']
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def _assign_field_data(self, company, company_json):
         """
@@ -556,12 +557,12 @@ class ScheduleEntriesSynchronizer(BatchConditionMixin, Synchronizer):
         'member': (models.Member, 'member')
     }
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.api_conditions = [
             "(type/identifier='S' or type/identifier='O')",
             "doneFlag=false",
         ]
-        super().__init__()
+        super().__init__(*args, **kwargs)
         # Only get schedule entries for tickets or opportunities that we
         # already have in the DB.
         ticket_ids = set(
@@ -853,12 +854,16 @@ class MemberSynchronizer(Synchronizer):
             photo_id = api_instance['photo']['id']
         # Fetch the image when:
         # CW tells us where the image is AND one of the following is true:
+        # * this is a full sync
         # * there's no previous member sync job record
+        # * the member's avatar doesn't already exist
         # * our member record is stale
         # * the member was created
-        # * the member's avatar doesn't already exist
-        if (not self.last_sync_job_time or member_stale or created or
-                not bool(instance.avatar)) and photo_id:
+        if photo_id and (self.full or
+                         not self.last_sync_job_time or
+                         not bool(instance.avatar) or
+                         member_stale or
+                         created):
             logger.info(
                 'Fetching avatar for member {}.'.format(username)
             )
@@ -893,9 +898,9 @@ class TicketSynchronizer(BatchConditionMixin, Synchronizer):
         'owner': (models.Member, 'owner')
     }
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.api_conditions = ['closedFlag=False']
-        super().__init__()
+        super().__init__(*args, **kwargs)
         # To get all open tickets, we can simply supply a `closedFlag=False`
         # condition for on-premise ConnectWise. But for hosted ConnectWise,
         # this results in timeouts for requests, so we also need to add a
@@ -1034,8 +1039,8 @@ class OpportunitySynchronizer(Synchronizer):
         'closedBy': (models.Member, 'closed_by')
     }
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # only synchronize Opportunities that do not have an OpportunityStatus
         # with the closedFlag=True
         open_statuses = list(

--- a/djconnectwise/tests/test_commands.py
+++ b/djconnectwise/tests/test_commands.py
@@ -31,12 +31,13 @@ def slug_to_title(slug):
 
 class AbstractBaseSyncTest(object):
 
-    def _test_sync(self, mock_call, return_value, cw_object, full=False):
+    def _test_sync(self, mock_call, return_value, cw_object,
+                   full_option=False):
         mock_call(return_value)
         out = io.StringIO()
 
         args = ['cwsync', cw_object]
-        if full:
+        if full_option:
             args.append('--full')
 
         call_command(*args, stdout=out)
@@ -59,7 +60,7 @@ class AbstractBaseSyncTest(object):
             cw_object
         ]
 
-        out = self._test_sync(*args, full=True)
+        out = self._test_sync(*args, full_option=True)
         obj_label = self._title_for_cw_object(cw_object)
         msg_tmpl = '{} Sync Summary - Created: 0, Updated: 0, Deleted: {}'
         msg = msg_tmpl.format(obj_label, len(return_value))
@@ -277,11 +278,11 @@ class TestSyncAllCommand(TestCase):
             apicall, fixture, cw_object = test_case.args
             apicall(fixture)
 
-    def _test_sync(self, full=False):
+    def _test_sync(self, full_option=False):
         out = io.StringIO()
         args = ['cwsync']
 
-        if full:
+        if full_option:
             args.append('--full')
 
         call_command(*args, stdout=out)
@@ -353,7 +354,7 @@ class TestSyncAllCommand(TestCase):
         for apicall, _, _ in self.test_args:
             apicall([])
 
-        output = self._test_sync(full=True)
+        output = self._test_sync(full_option=True)
 
         for apicall, fixture, cw_object in self.test_args:
             summary = full_sync_summary(slug_to_title(cw_object),

--- a/djconnectwise/tests/test_sync.py
+++ b/djconnectwise/tests/test_sync.py
@@ -718,8 +718,8 @@ class TestTicketSynchronizer(TestCase):
 
         method_name = 'djconnectwise.api.ServiceAPIClient.get_tickets'
         mock_call, _patch = mocks.create_mock_call(method_name, [])
-        synchronizer = sync.TicketSynchronizer()
-        synchronizer.sync(full=True)
+        synchronizer = sync.TicketSynchronizer(full=True)
+        synchronizer.sync()
         self.assertEqual(ticket_qset.count(), 0)
         _patch.stop()
 
@@ -774,10 +774,10 @@ class TestActivitySynchronizer(TestCase, SynchronizerTestMixin):
 
         method_name = 'djconnectwise.api.SalesAPIClient.get_activities'
         mock_call, _patch = mocks.create_mock_call(method_name, activity_list)
-        synchronizer = sync.ActivitySynchronizer()
+        synchronizer = sync.ActivitySynchronizer(full=True)
 
         created_count, updated_count, deleted_count = \
-            synchronizer.sync(full=True)
+            synchronizer.sync()
 
         # The existing Activity (#47) should be deleted and
         # null_member_activity should not be added to the db


### PR DESCRIPTION
Synchronize member avatars on each full sync. 

I moved the full sync option to be a class instance variable, so it could be accessed in the **MemberSynchronizer**  `update_or_create_instance` method.

All tests pass.