### PR TITLE
478 record partial or full sync job type

### DIFF
--- a/djconnectwise/admin.py
+++ b/djconnectwise/admin.py
@@ -9,7 +9,7 @@ from . import models
 class SyncJobAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'start_time', 'end_time', 'entity_name', 'success', 'added',
-        'updated', 'deleted'
+        'updated', 'deleted', 'sync_type'
     )
     list_filter = ('entity_name', )
 

--- a/djconnectwise/migrations/0047_syncjob_sync_type.py
+++ b/djconnectwise/migrations/0047_syncjob_sync_type.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djconnectwise', '0046_auto_20180104_1504'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='syncjob',
+            name='sync_type',
+            field=models.TextField(default='full'),
+        ),
+    ]

--- a/djconnectwise/migrations/0047_syncjob_sync_type.py
+++ b/djconnectwise/migrations/0047_syncjob_sync_type.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='syncjob',
             name='sync_type',
-            field=models.TextField(default='full'),
+            field=models.CharField(max_length=32, default='full'),
         ),
     ]

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -31,6 +31,7 @@ class SyncJob(models.Model):
     deleted = models.PositiveIntegerField(null=True)
     success = models.NullBooleanField()
     message = models.TextField(blank=True, null=True)
+    sync_type = models.TextField(default='full')
 
 
 class CallBackEntry(models.Model):

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -31,7 +31,7 @@ class SyncJob(models.Model):
     deleted = models.PositiveIntegerField(null=True)
     success = models.NullBooleanField()
     message = models.TextField(blank=True, null=True)
-    sync_type = models.TextField(default='full')
+    sync_type = models.CharField(max_length=32, default='full')
 
 
 class CallBackEntry(models.Model):

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -37,6 +37,10 @@ def log_sync_job(f):
         created_count = updated_count = deleted_count = 0
         sync_job = models.SyncJob()
         sync_job.start_time = timezone.now()
+        if kwargs.get('full'):
+            sync_job.sync_type = 'full'
+        else:
+            sync_job.sync_type = 'partial'
 
         try:
             created_count, updated_count, deleted_count = f(*args, **kwargs)

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -37,7 +37,7 @@ def log_sync_job(f):
         created_count = updated_count = deleted_count = 0
         sync_job = models.SyncJob()
         sync_job.start_time = timezone.now()
-        if kwargs.get('full'):
+        if sync_instance.full:
             sync_job.sync_type = 'full'
         else:
             sync_job.sync_type = 'partial'

--- a/djconnectwise/tests/test_sync.py
+++ b/djconnectwise/tests/test_sync.py
@@ -810,6 +810,7 @@ class TestSyncSettings(TestCase):
 class MockSynchronizer:
     error_message = 'One heck of an error'
     model_class = Ticket
+    full = False
 
     @log_sync_job
     def sync(self):
@@ -834,6 +835,7 @@ class TestSyncJob(TestCase):
                          sync_job.entity_name)
         self.assertEqual(message, sync_job.message)
         self.assertEqual(sync_job.success, success)
+        self.assertEqual(sync_job.sync_type, "partial")
 
     def test_sync_successful(self):
         created, updated, deleted = self.synchronizer.sync()


### PR DESCRIPTION
Add a sync_type field to the SyncJob model to indicate whether a _partial_ or _full_ synchronizer is run.  

Option is visible in the django admin page.

Tests and migrations were updated.