### PR TITLE
339 clear old syncjob records

### DIFF
--- a/djconnectwise/management/commands/_callback.py
+++ b/djconnectwise/management/commands/_callback.py
@@ -11,7 +11,7 @@ OPTION_NAME = 'callback'
 
 
 class Command(BaseCommand):
-    help = _('Registers the callback with the target connectwise system.')
+    help = str(_('Registers the callback with the target connectwise system.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/djconnectwise/management/commands/create_callback.py
+++ b/djconnectwise/management/commands/create_callback.py
@@ -4,5 +4,5 @@ from . import _callback
 
 
 class Command(_callback.Command):
-    help = _('Registers the callback with the target connectwise system.')
+    help = str(_('Registers the callback with the target connectwise system.'))
     ACTION = 'create'

--- a/djconnectwise/management/commands/cwclearoldsyncjobs.py
+++ b/djconnectwise/management/commands/cwclearoldsyncjobs.py
@@ -10,44 +10,37 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = _('Remove old sync job entries. Defaults to 4 weeks, but ' +
-             'the cutoff date can be customized by combining the days and ' +
-             'minutes options.')
+             'the cutoff date can be customized with the "days" option.')
 
     def add_arguments(self, parser):
         parser.add_argument('--days',
                             nargs='?',
                             type=int,
                             default=28,
-                            help='previous number of days of sync job logs to keep',
-                            )
-        parser.add_argument('--minutes',
-                            nargs='?',
-                            type=int,
-                            default=0,
-                            help='number of minutes of sync job logs to keep',
-                            )
+                            help='number of days worth of sync job ' +
+                                 'logs to keep', )
 
     def handle(self, *args, **options):
         days_option = options.get('days', 28)
-        minutes_option = options.get('minutes', 0)
 
-        cutoff_date = datetime.now() - timedelta(days=days_option,
-                                                 minutes=minutes_option)
+        verbosity = int(options['verbosity'])
+        if verbosity == 1:
+            logger.setLevel(logging.WARN)
+        elif verbosity == 2:
+            logger.setLevel(logging.INFO)
+
+        cutoff_date = datetime.now() - timedelta(days=days_option)
         old_entries = SyncJob.objects.exclude(start_time__gt=cutoff_date)
         count = old_entries.count()
 
-        if count == 0:
-            msg = 'There are no sync job entries older than {}'
-            logger.info(msg.format(
-                cutoff_date.isoformat(' '))
-            )
-        else:
-            try:
-                old_entries.delete()
+        try:
 
-                msg = '{} sync jobs older than {} were deleted'
-                logger.info(msg.format(
-                    count, cutoff_date.isoformat(' '))
-                )
-            except CommandError as e:
-                logger.error(e)
+            old_entries.delete()
+
+        except CommandError as e:
+            logger.error(e)
+        finally:
+            msg = '{} sync jobs older than {} were deleted'
+            logger.info(msg.format(
+                count, cutoff_date.isoformat(' '))
+            )

--- a/djconnectwise/management/commands/cwclearoldsyncjobs.py
+++ b/djconnectwise/management/commands/cwclearoldsyncjobs.py
@@ -1,0 +1,53 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import ugettext_lazy as _
+from datetime import datetime, timedelta
+import logging
+
+from djconnectwise.models import SyncJob
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = _('Remove old sync job entries. Defaults to 4 weeks, but ' +
+             'the cutoff date can be customized by combining the days and ' +
+             'minutes options.')
+
+    def add_arguments(self, parser):
+        parser.add_argument('--days',
+                            nargs='?',
+                            type=int,
+                            default=28,
+                            help='previous number of days of sync job logs to keep',
+                            )
+        parser.add_argument('--minutes',
+                            nargs='?',
+                            type=int,
+                            default=0,
+                            help='number of minutes of sync job logs to keep',
+                            )
+
+    def handle(self, *args, **options):
+        days_option = options.get('days', 28)
+        minutes_option = options.get('minutes', 0)
+
+        cutoff_date = datetime.now() - timedelta(days=days_option,
+                                                 minutes=minutes_option)
+        old_entries = SyncJob.objects.exclude(start_time__gt=cutoff_date)
+        count = old_entries.count()
+
+        if count == 0:
+            msg = 'There are no sync job entries older than {}'
+            logger.info(msg.format(
+                cutoff_date.isoformat(' '))
+            )
+        else:
+            try:
+                old_entries.delete()
+
+                msg = '{} sync jobs older than {} were deleted'
+                logger.info(msg.format(
+                    count, cutoff_date.isoformat(' '))
+                )
+            except CommandError as e:
+                logger.error(e)

--- a/djconnectwise/management/commands/cwclearoldsyncjobs.py
+++ b/djconnectwise/management/commands/cwclearoldsyncjobs.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = _('Remove old sync job entries. Defaults to 4 weeks, but ' +
-             'the cutoff date can be customized with the "days" option.')
+    help = str(_('Remove old sync job entries. Defaults to 4 weeks, but \
+           the cutoff date can be customized with the "days" option.'))
 
     def add_arguments(self, parser):
         parser.add_argument('--days',

--- a/djconnectwise/management/commands/cwsync.py
+++ b/djconnectwise/management/commands/cwsync.py
@@ -9,7 +9,7 @@ OPTION_NAME = 'connectwise_object'
 
 
 class Command(BaseCommand):
-    help = _('Synchronize the specified object with the Connectwise API')
+    help = str(_('Synchronize the specified object with the Connectwise API'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/djconnectwise/management/commands/delete_callback.py
+++ b/djconnectwise/management/commands/delete_callback.py
@@ -3,5 +3,5 @@ from . import _callback
 
 
 class Command(_callback.Command):
-    help = _('Deletes the callback from the target connectwise system.')
+    help = str(_('Deletes the callback from the target connectwise system.'))
     ACTION = 'delete'

--- a/djconnectwise/management/commands/list_callbacks.py
+++ b/djconnectwise/management/commands/list_callbacks.py
@@ -2,9 +2,11 @@ from django.core.management.base import BaseCommand, CommandError
 from djconnectwise.callback import TicketCallBackHandler
 from djconnectwise.api import ConnectWiseAPIError
 
+from django.utils.translation import ugettext_lazy as _
+
 
 class Command(BaseCommand):
-    help = 'Lists existing callbacks on target ConnectWise system.'
+    help = str(_('Lists existing callbacks on target ConnectWise system.'))
 
     def handle(self, *args, **options):
         handler = TicketCallBackHandler()

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -289,9 +289,9 @@ class BatchConditionMixin:
             optimal_size = self.get_optimal_size(unfetched_conditions)
             batch_conditions = unfetched_conditions[:optimal_size]
             del unfetched_conditions[:optimal_size]
-            batch_conditon = self.get_batch_condition(batch_conditions)
+            batch_condition = self.get_batch_condition(batch_conditions)
             batch_conditions = deepcopy(self.api_conditions)
-            batch_conditions.append(batch_conditon)
+            batch_conditions.append(batch_condition)
             results = super().get(results, conditions=batch_conditions)
         return results
 


### PR DESCRIPTION
Add a management command to clear old SyncJob db entries.  Defaults to 4 weeks.

