### PR TITLE
Handle Ticket Priority with a Custom icon

### DIFF
--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -363,7 +363,9 @@ class TicketPriority(TimeStampedModel):
         matches the common format ("Priority X - ..."), then return
         something sensible based on values seen in the wild.
         """
-        if self._color:
+        if self._color == "Custom":
+            return self.DEFAULT_COLOR
+        elif self._color:
             return self._color
         else:
             prio_number = None


### PR DESCRIPTION
ConnectWise allows a "Custom" icon to be used for Ticket Priorities.  django-connectwise only handles colours, so just treat it as the DEFAULT_COLOR