### PR TITLE
Fix DoesNotExist exception when syncing Service Notes 651

### DIFF
--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -408,9 +408,9 @@ class ServiceNoteSynchronizer(Synchronizer):
                 '- skipping.'.format(instance.id)
             )
         except ObjectDoesNotExist as e:
-            logger.warning(
-                'Service note {} has a ticketId that does not exist. {}'.
-                format(instance.id, e)
+            raise InvalidObjectException(
+                'Service note {} has a ticketId that does not exist.'
+                ' ObjectDoesNotExist Exception: '.format(instance.id, e)
             )
 
         for json_field, value in self.related_meta.items():

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -407,6 +407,11 @@ class ServiceNoteSynchronizer(Synchronizer):
                 'Service note {} has no ticketId key to find its target'
                 '- skipping.'.format(instance.id)
             )
+        except ObjectDoesNotExist as e:
+            logger.warning(
+                'Service note {} has a ticketId that does not exist. {}'.
+                format(instance.id, e)
+            )
 
         for json_field, value in self.related_meta.items():
             model_class, field_name = value


### PR DESCRIPTION
I was not able to figure out the root cause of this issue but have added a case for the DoesNotExist exception. I was able to reproduce the error in Django shell by calling the `_assign_field_data` function with a `ticketId` value that does not exist. The exception for KeyError is only catching errors where the object passed in has no `ticketId` key at all.