### PR TITLE
Django trying to create duplicate member

### DIFF
--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -210,12 +210,8 @@ class Synchronizer:
         """
         created = False
         try:
-            if self.lookup_key == 'identifier':
-                instance_identifier = api_instance[self.lookup_key]
-                instance = self.model_class.objects.get(identifier=instance_identifier)
-            else:
-                instance_pk = api_instance[self.lookup_key]
-                instance = self.model_class.objects.get(pk=instance_pk)
+            instance_pk = api_instance[self.lookup_key]
+            instance = self.model_class.objects.get(pk=instance_pk)
 
         except self.model_class.DoesNotExist:
             instance = self.model_class()
@@ -1139,7 +1135,6 @@ class ProjectSynchronizer(Synchronizer):
 class MemberSynchronizer(Synchronizer):
     client_class = api.SystemAPIClient
     model_class = models.Member
-    lookup_key = 'identifier'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1149,7 +1144,7 @@ class MemberSynchronizer(Synchronizer):
         instance.id = json_data['id']
         if instance.identifier == json_data['identifier']:
             raise InvalidObjectException(
-                'Identifier: {}, id: {} already exists.'.
+                'Identifier: {}, id: {} already exists - skipping.'.
                 format(instance.identifier, instance.id)
             )
         instance.first_name = json_data.get('firstName')

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -210,8 +210,13 @@ class Synchronizer:
         """
         created = False
         try:
-            instance_pk = api_instance[self.lookup_key]
-            instance = self.model_class.objects.get(pk=instance_pk)
+            if self.lookup_key == 'identifier':
+                instance_identifier = api_instance[self.lookup_key]
+                instance = self.model_class.objects.get(identifier=instance_identifier)
+            else:
+                instance_pk = api_instance[self.lookup_key]
+                instance = self.model_class.objects.get(pk=instance_pk)
+
         except self.model_class.DoesNotExist:
             instance = self.model_class()
             created = True
@@ -1134,6 +1139,7 @@ class ProjectSynchronizer(Synchronizer):
 class MemberSynchronizer(Synchronizer):
     client_class = api.SystemAPIClient
     model_class = models.Member
+    lookup_key = 'identifier'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1141,6 +1147,11 @@ class MemberSynchronizer(Synchronizer):
 
     def _assign_field_data(self, instance, json_data):
         instance.id = json_data['id']
+        if instance.identifier == json_data['identifier']:
+            raise InvalidObjectException(
+                'Identifier: {}, id: {} already exists.'.
+                format(instance.identifier, instance.id)
+            )
         instance.first_name = json_data.get('firstName')
         instance.last_name = json_data.get('lastName')
         instance.identifier = json_data.get('identifier')

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -212,7 +212,6 @@ class Synchronizer:
         try:
             instance_pk = api_instance[self.lookup_key]
             instance = self.model_class.objects.get(pk=instance_pk)
-
         except self.model_class.DoesNotExist:
             instance = self.model_class()
             created = True


### PR DESCRIPTION
**Steps to reproduce error:**
1. In Django admin, delete a member
2. Create a new member with the same identifier as the deleted member
3. Run `cwsync member --full`. Without catching exception sync should fail with
integrity error `DETAIL:  Key (identifier)=(User9) already exists.`

Catching the exception and skipping allows it to sync the next time. Thanks to
Sam for pointing that out.

**To verify fix works:**
1. In Django admin, delete a member
2. Create a new member with the same identifier as the deleted member
3. Run `cwsync member --full`
4. Check the output and verify integrity error was caught and skipped. Sync summary should
note that a member was deleted.
5. Run `cwsync member --full` again, new member should be created with correct member from CW.