### PR TITLE
Fix attribute error

### DIFF
--- a/djconnectwise/signals.py
+++ b/djconnectwise/signals.py
@@ -13,8 +13,8 @@ def handle_ticket_sla_update_pre_save(sender, instance, **kwargs):
     # Signal for updating a tickets SLA information if necessary
     try:
         old_ticket = Ticket.objects.get(id=instance.id)
-        if not old_ticket.status.escalation_status or \
-                not instance.status.escalation_status:
+        if not getattr(old_ticket.status, 'escalation_status', None) or \
+                not getattr(instance.status, 'escalation_status', None):
             # If there are unit tests running that don't require SLA data
             # or if the instance does not have SLA data, return
             return


### PR DESCRIPTION
An attribute error was raised when trying to access `old_ticket.status.escalation_status` because `old_ticket.status` was None. I added getattr to get the ticket's `escalation_status` if it exists else return None if the status is not set.