### PR TITLE
792 fix keyerror to improve image extension handling generate thumbnail

### DIFF
--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -1226,10 +1226,12 @@ class MemberSynchronizer(Synchronizer):
                 current_filename = generate_filename(thumbnail_size[size],
                                                      current_avatar, extension)
                 filename = '{}.{}'.format(get_hash(avatar), extension)
-                avatar_file, filename = generate_thumbnail(
-                    avatar, thumbnail_size[size],
-                    extension, filename)
-
+                try:
+                    avatar_file, filename = generate_thumbnail(
+                        avatar, thumbnail_size[size],
+                        extension, filename)
+                except Exception as e:
+                    logger.warning("Error saving member avatar. {}".format(e))
                 # If this is a new image, the current avatar image
                 # needs to be removed. Plus local file storage won't
                 # overwrite like DO spaces so delete to prevent

--- a/djconnectwise/utils.py
+++ b/djconnectwise/utils.py
@@ -70,10 +70,7 @@ def generate_thumbnail(avatar, size, extension, filename):
         extension = 'jpeg'
 
     byte_stream = BytesIO()
-    try:
-        thumbnail.save(byte_stream, format=extension)
-    except KeyError:
-        pass
+    thumbnail.save(byte_stream, format=extension)
     avatar_file = ContentFile(byte_stream.getvalue())
 
     return avatar_file, filename

--- a/djconnectwise/utils.py
+++ b/djconnectwise/utils.py
@@ -66,11 +66,14 @@ def generate_thumbnail(avatar, size, extension, filename):
     avatar_image = Image.open(BytesIO(avatar))
     thumbnail = ImageOps.fit(avatar_image, size, Image.ANTIALIAS)
 
-    if extension == 'jpg':
+    if extension.lower() == 'jpg':
         extension = 'jpeg'
 
     byte_stream = BytesIO()
-    thumbnail.save(byte_stream, format=extension)
+    try:
+        thumbnail.save(byte_stream, format=extension)
+    except KeyError:
+        pass
     avatar_file = ContentFile(byte_stream.getvalue())
 
     return avatar_file, filename


### PR DESCRIPTION
Added try except to log errors and keep the sync running. Also added lower() to file extension to make file extensions more uniform. 