### PR TITLE
Add improvements, fix bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'django-braces',
         'django-extensions',
         'retrying',
+        'Pillow',
     ],
     test_suite='runtests.suite',
     tests_require=[


### PR DESCRIPTION
* Removed references in comments to DO spaces
* Added Pillow as a dependency. Note this is the active fork of PIL. See https://github.com/python-pillow/Pillow 
* Placed the logger before the avatar save 

I also found a bug in the check for when thumbnails should be generated. It was checking for the avatar image name without appending the 20x20 or 80x80 so the avatar image name never exists because the get saved with the image dimension append to the filename. Now it checks to see if the 20x20 thumbnail exists. Didn't think it would be necessary to add a check for the 80x80 thumbnails as well.