### PR TITLE
688 don t sync project tickets that are part of closed projects

### DIFF
--- a/djconnectwise/__init__.py
+++ b/djconnectwise/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (0, 3, 23, 'final')
+VERSION = (0, 3, 24, 'final')
 
 # pragma: no cover
 if VERSION[-1] != "final":


### PR DESCRIPTION
Filtered out open tickets on closed project using API conditions. Tested with cwsync to training CW and verified it is not syncing open tickets in closed project. Added unit test.