### PR TITLE
Remove parse from dateEntered

### DIFF
--- a/djconnectwise/__init__.py
+++ b/djconnectwise/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (0, 3, 29, 'final')
+VERSION = (0, 3, 30, 'final')
 
 # pragma: no cover
 if VERSION[-1] != "final":

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -515,6 +515,9 @@ class Calendar(models.Model):
             return sla_minutes
 
     def next_phase_expiry(self, sla_hours, ticket):
+        if not ticket.entered_date_utc:
+            return
+
         start = ticket.entered_date_utc.astimezone(tz=None)
 
         # Start counting from the start of the next business day if the

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -1348,7 +1348,7 @@ class TicketSynchronizer(BatchConditionMixin, Synchronizer):
         instance.id = json_data['id']
         instance.summary = json_data['summary']
         instance.closed_flag = json_data.get('closedFlag')
-        instance.entered_date_utc = parse(json_data.get('dateEntered'))
+        instance.entered_date_utc = json_data.get('dateEntered')
         instance.last_updated_utc = json_data.get('_info').get('lastUpdated')
         instance.required_date_utc = json_data.get('requiredDate')
         instance.resources = json_data.get('resources')

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -1343,12 +1343,12 @@ class TicketSynchronizer(BatchConditionMixin, Synchronizer):
         created = instance.id is None
         # If the status results in a move to a different column
         original_status = not created and instance.status or None
+        entered_date_utc = json_data.get('dateEntered')
 
         json_data_id = json_data['id']
         instance.id = json_data['id']
         instance.summary = json_data['summary']
         instance.closed_flag = json_data.get('closedFlag')
-        instance.entered_date_utc = json_data.get('dateEntered')
         instance.last_updated_utc = json_data.get('_info').get('lastUpdated')
         instance.required_date_utc = json_data.get('requiredDate')
         instance.resources = json_data.get('resources')
@@ -1364,6 +1364,11 @@ class TicketSynchronizer(BatchConditionMixin, Synchronizer):
         instance.date_resolved_utc = json_data.get('dateResolved')
         instance.date_resplan_utc = json_data.get('dateResplan')
         instance.date_responded_utc = json_data.get('dateResponded')
+
+        if entered_date_utc:
+            # Parse the date here so that a datetime object is
+            # available for SLA calculation.
+            instance.entered_date_utc = parse(entered_date_utc)
 
         for json_field, value in self.related_meta.items():
             model_class, field_name = value


### PR DESCRIPTION
`entered_date_utc` on the Ticket model already allowed nulls, so that wasn't an issue.  An empty `dateEntered` field was passed to dateutils parse which raised the TypeError. I don't think the parse is necessary. I think Django parses the date string when it gets saved as a DateTimeField. Plus we have other date fields on the Ticket model don't use parse either.