### PR TITLE
Check for status

### DIFF
--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -1248,7 +1248,7 @@ class Ticket(TimeStampedModel):
             self.date_resplan_utc = None
             self.date_responded_utc = None
 
-        if not self.sla:
+        if not self.sla or not self.status:
             return
 
         # SLAP might exist, which may alter the SLA target time

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -1249,7 +1249,14 @@ class Ticket(TimeStampedModel):
             self.date_responded_utc = None
             return
 
-        if not self.sla or not self.status:
+        if not self.status:
+            logger.error(
+                'Ticket {}-{}, does not have a status set. '
+                'Skipping SLA calculation.'.format(self.id, self.summary)
+            )
+            return
+
+        if not self.sla:
             return
 
         # SLAP might exist, which may alter the SLA target time


### PR DESCRIPTION
From what I can tell, it seems like the ticket gets synced from the connectwise_callback but does not have a status set (even though I was able to see it set in Postman) then an AttributeError is raised. 

Simply returning if the ticket doesn't have a status should prevent this error. I am very curious about how the ticket doesn't seem have a status set but not sure I should put more time into finding out as this only seems to be happening for a few tickets. 
