### PR TITLE
Fix double period error formatting

### DIFF
--- a/djconnectwise/api.py
+++ b/djconnectwise/api.py
@@ -207,7 +207,9 @@ class ConnectWiseAPIClient(object):
             primary_error_msg = '{}.'.format(stripped_message)
             if error.get('errors'):
                 for error_message in error.get('errors'):
-                    messages.append('{}.'.format(error_message.get('message')))
+                    messages.append(
+                        '{}.'.format(error_message.get('message').rstrip('.'))
+                    )
 
             messages = ' The error was: '.join(messages)
 


### PR DESCRIPTION
Found a case where an error message had two periods appended to the end of it. I seem to recall some error messages having periods and others without periods. I'm thinking its safe to remove a period if its present then add it back in our message format. 