### PR TITLE
951 unsupported operand type s for in djconnectwise models in get sla time

### DIFF
--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -437,10 +437,12 @@ class Calendar(models.Model):
         # get sla minutes for first day
         end_of_day = self.get_day_hours(False, start.weekday())
 
-        if end_of_day and \
-                not self.is_holiday(timezone.now().astimezone(tz=None)):
+        if end_of_day \
+                and not self.is_holiday(timezone.now().astimezone(tz=None)):
             end_of_day = datetime.timedelta(hours=end_of_day.hour,
                                             minutes=end_of_day.minute)
+        else:
+            end_of_day = None
 
         if start.date() == end.date():
             if end_of_day:

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -446,15 +446,17 @@ class Calendar(models.Model):
 
         if start.date() == end.date():
 
-            if end_of_day and start_day_end_time > end.time():
-                end_time = datetime.timedelta(
+            if end_of_day:
+                ticket_end_time = datetime.timedelta(
                     hours=end.hour,
                     minutes=end.minute
                 )
+                end_time = min(ticket_end_time, end_of_day)
+
                 minutes = (end_time - start_time).total_seconds() / 60
             # return sla time between start and end of day/end time, or zero
             # if start and end was outside of work hours
-            return minutes if minutes >= 0 else 0
+            return max(minutes, 0)
         else:
             if end_of_day and \
                     not self.is_holiday(timezone.now().astimezone(tz=None)):

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -437,8 +437,8 @@ class Calendar(models.Model):
         # get sla minutes for first day
         end_of_day = self.get_day_hours(False, start.weekday())
 
-        if end_of_day \
-                and not self.is_holiday(timezone.now().astimezone(tz=None)):
+        if end_of_day and \
+                not self.is_holiday(timezone.now().astimezone(tz=None)):
             end_of_day = datetime.timedelta(hours=end_of_day.hour,
                                             minutes=end_of_day.minute)
         else:

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -434,10 +434,19 @@ class Calendar(models.Model):
         start_time = datetime.timedelta(hours=start.hour,
                                         minutes=start.minute)
 
-        if start.date() == end.date():
-            start_day_end_time = self.get_day_hours(False, start.weekday())
-            if start_day_end_time and start_day_end_time > end.time():
+        # Get sla minutes for first day
+        start_day_end_time = self.get_day_hours(False, start.weekday())
 
+        if start_day_end_time and \
+                not self.is_holiday(timezone.now().astimezone(tz=None)):
+            end_of_day = datetime.timedelta(hours=start_day_end_time.hour,
+                                            minutes=start_day_end_time.minute)
+        else:
+            end_of_day = None
+
+        if start.date() == end.date():
+
+            if end_of_day and start_day_end_time > end.time():
                 end_time = datetime.timedelta(
                     hours=end.hour,
                     minutes=end.minute
@@ -447,16 +456,6 @@ class Calendar(models.Model):
             # if start and end was outside of work hours
             return minutes if minutes >= 0 else 0
         else:
-            # get sla minutes for first day
-            end_of_day = self.get_day_hours(False, start.weekday())
-
-            if end_of_day and \
-                    not self.is_holiday(timezone.now().astimezone(tz=None)):
-                end_of_day = datetime.timedelta(hours=end_of_day.hour,
-                                                minutes=end_of_day.minute)
-            else:
-                end_of_day = None
-
             if end_of_day and \
                     not self.is_holiday(timezone.now().astimezone(tz=None)):
                 first_day_minutes = (end_of_day - start_time).total_seconds() \

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -447,13 +447,14 @@ class Calendar(models.Model):
         if start.date() == end.date():
 
             if end_of_day:
-                ticket_end_time = datetime.timedelta(
-                    hours=end.hour,
-                    minutes=end.minute
-                )
-                end_time = min(ticket_end_time, end_of_day)
 
-                minutes = (end_time - start_time).total_seconds() / 60
+                end_time = min(start_day_end_time, end.time())
+                end_time_delta = datetime.timedelta(
+                    hours=end_time.hour,
+                    minutes=end_time.minute
+                )
+
+                minutes = (end_time_delta - start_time).total_seconds() / 60
             # return sla time between start and end of day/end time, or zero
             # if start and end was outside of work hours
             return max(minutes, 0)

--- a/djconnectwise/models.py
+++ b/djconnectwise/models.py
@@ -434,28 +434,29 @@ class Calendar(models.Model):
         start_time = datetime.timedelta(hours=start.hour,
                                         minutes=start.minute)
 
-        # get sla minutes for first day
-        end_of_day = self.get_day_hours(False, start.weekday())
-
-        if end_of_day and \
-                not self.is_holiday(timezone.now().astimezone(tz=None)):
-            end_of_day = datetime.timedelta(hours=end_of_day.hour,
-                                            minutes=end_of_day.minute)
-        else:
-            end_of_day = None
-
         if start.date() == end.date():
-            if end_of_day:
+            start_day_end_time = self.get_day_hours(False, start.weekday())
+            if start_day_end_time and start_day_end_time > end.time():
+
                 end_time = datetime.timedelta(
                     hours=end.hour,
-                    minutes=end.minute) if \
-                    self.get_day_hours(False, start.weekday()) > \
-                    end.time() else end_of_day
+                    minutes=end.minute
+                )
                 minutes = (end_time - start_time).total_seconds() / 60
             # return sla time between start and end of day/end time, or zero
             # if start and end was outside of work hours
             return minutes if minutes >= 0 else 0
         else:
+            # get sla minutes for first day
+            end_of_day = self.get_day_hours(False, start.weekday())
+
+            if end_of_day and \
+                    not self.is_holiday(timezone.now().astimezone(tz=None)):
+                end_of_day = datetime.timedelta(hours=end_of_day.hour,
+                                                minutes=end_of_day.minute)
+            else:
+                end_of_day = None
+
             if end_of_day and \
                     not self.is_holiday(timezone.now().astimezone(tz=None)):
                 first_day_minutes = (end_of_day - start_time).total_seconds() \


### PR DESCRIPTION
Simply added in an else. As far as I can tell `get_sla_time` only gets called when leaving a do not escalate state. So if the ticket leaves a non escalate state on a holiday, setting `end_of_day` to none will return 0 minutes.