### PR TITLE
[ISSUE-4145] Prevent the project tickets from sync if the project is closed

### DIFF
--- a/djconnectwise/__init__.py
+++ b/djconnectwise/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (1, 10, 0, 'final')
+VERSION = (1, 10, 1, 'final')
 
 # pragma: no cover
 if VERSION[-1] != "final":

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -3149,13 +3149,8 @@ class ProjectTicketSynchronizer(TicketSynchronizerMixin,
 
         self.set_relations(instance, json_data)
 
-        # Check if project exists - skip if not
         if instance.project is None:
-            raise InvalidObjectException(
-                'Project ticket {} has no project - skipping.'.format(
-                    instance.id
-                )
-            )
+            return None
 
         return instance
 
@@ -3165,22 +3160,6 @@ class ProjectTicketSynchronizer(TicketSynchronizerMixin,
         ]
         return self.model_class.objects.filter(
             record_type__in=project_record_types)
-
-    def _instance_ids(self, filter_params=None):
-        tickets_qset = self.filter_by_record_type()
-
-        if not filter_params:
-            ids = tickets_qset.values_list(self.lookup_key, flat=True)
-        else:
-            ids = tickets_qset.filter(filter_params).values_list(
-                self.lookup_key, flat=True
-            )
-        return set(ids)
-
-    def get_delete_qset(self, stale_ids):
-        tickets = self.filter_by_record_type()
-        return tickets.filter(pk__in=stale_ids)
-
 
 class CalendarSynchronizer(Synchronizer):
     client_class = api.ScheduleAPIClient

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -270,6 +270,9 @@ class Synchronizer:
     def _is_instance_changed(self, instance):
         return instance.tracker.changed()
 
+    def _is_instance_valid(self, instance):
+        return instance
+
     def update_or_create_instance(self, api_instance):
         """
         Creates and returns an instance if it does not already exist.
@@ -288,7 +291,7 @@ class Synchronizer:
 
             # This will return the created instance, the updated instance, or
             # if the instance is skipped an unsaved copy of the instance.
-            if record is None:
+            if not self._is_instance_valid(instance):
                 result = SKIPPED
             elif result == CREATED:
                 if self.model_class is models.TicketTracker:
@@ -3134,6 +3137,9 @@ class ProjectTicketSynchronizer(TicketSynchronizerMixin,
     client_class = api.ProjectAPIClient
     task_synchronizer_class = ProjectTicketTaskSynchronizer
 
+    def _is_instance_valid(self, instance):
+        return instance.project is not None
+
     def _assign_field_data(self, instance, json_data):
         instance = super()._assign_field_data(instance, json_data)
 
@@ -3150,9 +3156,6 @@ class ProjectTicketSynchronizer(TicketSynchronizerMixin,
             instance.record_type = models.Ticket.PROJECT_TICKET
 
         self.set_relations(instance, json_data)
-
-        if instance.project is None:
-            return None
 
         return instance
 

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -287,7 +287,7 @@ class Synchronizer:
             result = CREATED
 
         try:
-            record = self._assign_field_data(instance, api_instance)
+            self._assign_field_data(instance, api_instance)
 
             # This will return the created instance, the updated instance, or
             # if the instance is skipped an unsaved copy of the instance.


### PR DESCRIPTION
**Issue link:** [Project and phase fields are not populating with initial data for project tickets](https://gitlab.com/topleft.team/apps/django-topleft/-/issues/4145)