### PR TITLE
fix backslashes in standard notes

### DIFF
--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -2116,7 +2116,10 @@ class StandardNoteSynchronizer(Synchronizer):
     def _assign_field_data(self, instance, json_data):
         instance.id = json_data.get('id')
         instance.name = json_data.get('name')
-        instance.contents = json_data.get('contents')
+        contents = json_data.get('contents')
+        # connectwise uses backslashes to escape periods, we need to remove them
+        instance.contents = contents.replace('\\', '')
+
         self.set_relations(instance, json_data)
         return instance
 

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -2117,7 +2117,8 @@ class StandardNoteSynchronizer(Synchronizer):
         instance.id = json_data.get('id')
         instance.name = json_data.get('name')
         contents = json_data.get('contents')
-        # connectwise uses backslashes to escape periods, we need to remove them
+        # connectwise uses backslashes to escape periods, we need to remove
+        # them.
         instance.contents = contents.replace('\\', '')
 
         self.set_relations(instance, json_data)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = open('README.md').read()
 
-VERSION = (1, 18, 0)
+VERSION = (1, 18, 1)
 
 project_version = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
**Gitlab issue**: [Backslashes appearing in CW standard note](https://gitlab.com/topleft.team/apps/django-topleft/-/work_items/4571)
