### PR TITLE
Support Python 3.14 and Django 6.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,17 +20,17 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.txt
           pip install --upgrade -r requirements_test.txt
-          python setup.py install
+          pip install -e .
       - name: Run tests
         run: |
           flake8 .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+        django-version: ['4.2', '5.2', '6.0']
+        exclude:
+          # Django 4.2 supports Python 3.8 - 3.12 only.
+          - python-version: '3.13'
+            django-version: '4.2'
+          - python-version: '3.14'
+            django-version: '4.2'
+    name: Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r requirements.txt
+          pip install --upgrade -r requirements_test.txt
+          pip install -e .
+          pip install "django~=${{ matrix.django-version }}.0"
+      - name: Lint
+        run: flake8 .
+      - name: Run tests
+        run: python runtests.py

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ ENV/
 
 .idea/
 .swp
+
+# Local virtualenvs
+.venv/
+.venv*/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include djconnectwise *
 include README.md
 exclude *.orig *.pyc *.wpr *.swp
+global-exclude *.orig *.pyc *.pyo *.wpr *.swp
+prune djconnectwise/**/__pycache__

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,17 @@ coverage: ## check code coverage quickly with the default Python
 	coverage report -m
 
 install: clean
-	python setup.py install
+	pip install -e .
 
 lint: ## check style with flake8
 	# flake8 config file at tox.ini
 	flake8 .
 
 test: clean lint
-	python setup.py test
+	python runtests.py
 
 sdist: test
-	python setup.py sdist
+	python -m build --sdist
 
 upload: sdist
     # You must have a ~/.pypirc file with your username and password.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ members, companies, etc.) and callbacks.
 
 ## Requirements
 
--  Python 3.5
--  Django 2.0
+-  Python 3.12, 3.13 or 3.14
+-  Django 4.2, 5.2 or 6.0
 
-Other versions may work; we haven't tried.
+Other versions may work; we haven't tried. Django 4.2 is only tested on
+Python 3.12, since that's the newest Python it supports.
+
+The models define `GinIndex`es on their user-defined-field data, so PostgreSQL
+is the expected database backend.
 
 ## Installation
 
@@ -20,7 +24,7 @@ From source:
 
     git clone git@github.com:KerkhoffTechnologies/django-connectwise.git
     cd django-connectwise
-    python setup.py install
+    pip install -e .
 
 ## Usage
 
@@ -30,6 +34,7 @@ From source:
     INSTALLED_APPS = [
         ...
         'djconnectwise',
+        'django.contrib.postgres',  # Required by the models' GinIndexes.
         ...
     ]
     ```
@@ -85,13 +90,14 @@ To de-register your callbacks, use the `callbacks_deleted` management command.
 Prepare your environment:
 
 ```
+pip install --upgrade -r requirements.txt
 pip install --upgrade -r requirements_test.txt
+pip install -e .
 ```
 
 Try one of:
 
     ./runtests.py
-    python setup.py test
     make test
 
 ## Contributing

--- a/djconnectwise/__init__.py
+++ b/djconnectwise/__init__.py
@@ -2,5 +2,3 @@
 from importlib.metadata import version
 
 __version__ = version("django-connectwise")
-
-default_app_config = 'djconnectwise.apps.DjangoConnectwiseConfig'

--- a/djconnectwise/api.py
+++ b/djconnectwise/api.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 from json import JSONDecodeError
 from urllib.parse import urlparse
 
-import pytz
 import requests
 from django.conf import settings
 from django.core.cache import cache
@@ -444,7 +443,7 @@ class ConnectWiseAPIClient(object):
 
             elif isinstance(value, datetime.datetime):
                 field_update['value'] = value.astimezone(
-                    pytz.timezone('UTC')
+                    datetime.timezone.utc
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
             elif isinstance(value, models.Model):
@@ -483,7 +482,7 @@ class ConnectWiseAPIClient(object):
 
             if isinstance(value, datetime.datetime):
                 value = value.astimezone(
-                    pytz.timezone('UTC')).strftime(
+                    datetime.timezone.utc).strftime(
                     "%Y-%m-%dT%H:%M:%SZ")
             elif isinstance(value, models.Model):
                 value = {'id': value.id}
@@ -671,13 +670,13 @@ class ScheduleAPIClient(ConnectWiseAPIClient):
         date_start = kwargs.get("date_start")
         if date_start:
             body["dateStart"] = date_start.astimezone(
-                pytz.timezone('UTC')).strftime("%Y-%m-%dT%H:%M:%SZ")
+                datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         date_end = kwargs.get("date_end")
         if date_end:
             body["dateEnd"] = kwargs.get("date_end")
             body["dateEnd"] = date_end.astimezone(
-                pytz.timezone('UTC')).strftime("%Y-%m-%dT%H:%M:%SZ")
+                datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         allow_conflicts = kwargs.get("allow_conflicts")
         if allow_conflicts is not None:
@@ -704,7 +703,7 @@ class ScheduleAPIClient(ConnectWiseAPIClient):
             date_start = kwargs.pop('date_start')
             if date_start is not None:
                 date_start = date_start.astimezone(
-                    pytz.timezone('UTC')).strftime("%Y-%m-%dT%H:%M:%SZ")
+                    datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             body.append({
                 'op': 'replace',
                 'path': 'dateStart',
@@ -715,7 +714,7 @@ class ScheduleAPIClient(ConnectWiseAPIClient):
             date_end = kwargs.pop('date_end')
             if date_end is not None:
                 date_end = date_end.astimezone(
-                    pytz.timezone('UTC')).strftime("%Y-%m-%dT%H:%M:%SZ")
+                    datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             body.append({
                 'op': 'replace',
                 'path': 'dateEnd',
@@ -810,7 +809,7 @@ class TimeAPIClient(ConnectWiseAPIClient):
 
     def post_time_entry(self, target_data, **kwargs):
         time_start = kwargs.get("time_start")
-        time_start = time_start.astimezone(pytz.timezone('UTC')).strftime(
+        time_start = time_start.astimezone(datetime.timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ")
 
         body = {
@@ -838,7 +837,7 @@ class TimeAPIClient(ConnectWiseAPIClient):
 
         time_end = kwargs.get("time_end")
         if time_end:
-            time_end = time_end.astimezone(pytz.timezone('UTC')).strftime(
+            time_end = time_end.astimezone(datetime.timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
             body.update({"timeEnd": time_end})
 
@@ -1260,7 +1259,7 @@ class TicketAPIMixin:
 
             if isinstance(value, datetime.datetime):
                 value = value.astimezone(
-                        pytz.timezone('UTC')).strftime(
+                        datetime.timezone.utc).strftime(
                         "%Y-%m-%dT%H:%M:%SZ")
             elif isinstance(value, models.Model):
                 value = {'id': value.id}
@@ -1286,7 +1285,7 @@ class TicketAPIMixin:
             if isinstance(value, datetime.datetime):
                 field_update.update({
                     'value': value.astimezone(
-                        pytz.timezone('UTC')).strftime(
+                        datetime.timezone.utc).strftime(
                             "%Y-%m-%dT%H:%M:%SZ")
                 })
 

--- a/djconnectwise/apps.py
+++ b/djconnectwise/apps.py
@@ -3,3 +3,8 @@ from django.apps import AppConfig
 
 class DjangoConnectwiseConfig(AppConfig):
     name = 'djconnectwise'
+    # Django 6.0 changed the global DEFAULT_AUTO_FIELD default from AutoField
+    # to BigAutoField. Pin it here so this app's primary keys don't silently
+    # depend on the host project's setting; without it, upgrading projects
+    # would be prompted to generate an AlterField migration for every model.
+    default_auto_field = 'django.db.models.AutoField'

--- a/djconnectwise/tests/baker_recipes.py
+++ b/djconnectwise/tests/baker_recipes.py
@@ -1,4 +1,4 @@
-from model_mommy.recipe import Recipe, seq, foreign_key
+from model_bakery.recipe import Recipe, seq, foreign_key
 from djconnectwise.models import ConnectWiseBoard, \
     TicketPriority, Ticket, Company, Member, Project
 

--- a/djconnectwise/tests/mocks.py
+++ b/djconnectwise/tests/mocks.py
@@ -1,5 +1,5 @@
 import os
-from mock import patch
+from unittest.mock import patch
 
 from datetime import datetime, date, time
 import json

--- a/djconnectwise/tests/test_models.py
+++ b/djconnectwise/tests/test_models.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from djconnectwise.models import MyCompanyOther, Holiday, HolidayList, \
     Ticket, Calendar, TicketPriority, BoardStatus
-from model_mommy import mommy
+from model_bakery import baker
 from test_plus.test import TestCase
 
 ticket_statuses_names = [
@@ -29,23 +29,23 @@ escalation_stages = [
 class ModelTestCase(TestCase):
 
     def setUp(self):
-        self.members = mommy.make_recipe(
+        self.members = baker.make_recipe(
             'djconnectwise.tests.member',
             _quantity=3
         )
-        self.projects = mommy.make_recipe(
+        self.projects = baker.make_recipe(
             'djconnectwise.tests.project',
             _quantity=4,
         )
-        self.companies = mommy.make_recipe(
+        self.companies = baker.make_recipe(
             'djconnectwise.tests.company',
             _quantity=2
         )
-        self.ticket_priorities = mommy.make_recipe(
+        self.ticket_priorities = baker.make_recipe(
             'djconnectwise.tests.ticket_priority',
             _quantity=3
         )
-        self.connectwise_boards = mommy.make_recipe(
+        self.connectwise_boards = baker.make_recipe(
             'djconnectwise.tests.connectwise_board',
             _quantity=3,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-pytz==2022.1
-botocore==1.25.4
-boto3==1.22.4
-django-storages==1.12.3
-Pillow==10.3.0
-build==1.2.2.post1
+botocore>=1.34
+boto3>=1.34
+django-storages>=1.14
+Pillow>=10.3
+build>=1.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,10 @@
-coverage>=4.3
-flake8>=2.1.0
-django-test-plus>=1.4.0
-mock
-freezegun
-responses
-model-mommy
-django-coverage
-names
+coverage>=7.0
+flake8>=7.0
+django-test-plus>=2.0
+responses>=0.25
+model-bakery>=1.17
+names>=0.3
+# runtests.py puts django.contrib.postgres in INSTALLED_APPS (the GinIndex
+# definitions on Ticket/Project/Opportunity/Activity require it), and that app
+# cannot be imported without a psycopg driver present.
+psycopg[binary]>=3.2

--- a/runtests.py
+++ b/runtests.py
@@ -4,7 +4,6 @@ import sys
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test.utils import get_runner
 import django
 import tempfile
 
@@ -28,6 +27,9 @@ settings.configure(
         'django.contrib.contenttypes',
         'django.contrib.auth',
         'django.contrib.sessions',
+        # Required by the GinIndex definitions on Ticket, Project,
+        # Opportunity and Activity (Django 6.0 system check postgres.E005).
+        'django.contrib.postgres',
     ),
     CONNECTWISE_SERVER_URL='https://localhost',
     CONNECTWISE_CREDENTIALS={
@@ -95,15 +97,6 @@ def flake8_main():
 
     print("Failed: flake8 failed." if command else "Success. flake8 passed.")
     return command
-
-
-def suite():
-    """
-    Set up and return a test suite. This is used in `python setup.py test`.
-    """
-    _setup()
-    runner_cls = get_runner(settings)
-    return runner_cls().build_suite(test_labels=None)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = open('README.md').read()
 
-VERSION = (1, 25, 3)
+VERSION = (1, 26, 0)
 
 project_version = '.'.join(map(str, VERSION))
 
@@ -24,22 +24,19 @@ setup(
     url="https://github.com/KerkhoffTechnologies/django-connectwise",
     include_package_data=True,
     license='MIT',
+    python_requires='>=3.12',
     install_requires=[
         'requests',
-        'django',
+        'django>=4.2',
         'python-dateutil',
         'django-model-utils',
         'django-braces',
         'django-extensions',
         'retrying',
         'Pillow',
-    ],
-    test_suite='runtests.suite',
-    tests_require=[
-        'responses',
-        'model-mommy',
-        'django-coverage',
-        'names'
+        # sync.py catches botocore's NoCredentialsError when writing member
+        # avatars to storage.
+        'botocore',
     ],
     # Django likes to inspect apps for /migrations directories, and can't if
     # package is installed as a egg. zip_safe=False disables installation as
@@ -48,11 +45,17 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Development Status :: 3 - Alpha',

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,3 @@
 [flake8]
 # Migrations are auto-generated (mostly); let's not worry about them.
-exclude = .eggs,djconnectwise/tests/fixtures.py,djconnectwise/migrations/,build,djconnectwise/tests/mommy_recipes.py,djconnectwise/apps.py
+exclude = .eggs,djconnectwise/tests/fixtures.py,djconnectwise/migrations/,build,dist,djconnectwise/tests/bakery_recipes.py,djconnectwise/apps.py,.git,__pycache__,.venv,.venv*,venv,env


### PR DESCRIPTION
Tested on Python 3.12/3.13/3.14 against Django 4.2, 5.2 and 6.0. The Django floor stays at 4.2 - nothing here requires 6.0.

Three actual breakages:

- pytz: Django 5.0 dropped pytz support, so it was no longer being installed. Every use was value.astimezone(pytz.timezone('UTC')), now datetime.timezone.utc.

- DEFAULT_AUTO_FIELD: Django 6.0 changed the global default from AutoField to BigAutoField, so on 6.0 the app reported unmigrated changes and makemigrations generated an AlterField for the primary key of every model - an integer to bigint rewrite of every PK and FK in an existing install. Pin default_auto_field on the AppConfig so the schema doesn't depend on the host project's setting.

- postgres.E005: Django 6.0 added a system check requiring django.contrib.postgres in INSTALLED_APPS when a model declares a GinIndex, which Ticket, Project, Opportunity and Activity all do. Consuming projects must now add it; documented in the README and added to the test settings.

Also:

- model-mommy (unmaintained, warns to use model_bakery) to model-bakery, and mommy_recipes.py to baker_recipes.py. Drop mock for stdlib unittest.mock, and django-coverage/freezegun which nothing imported.

- Packaging: python_requires >=3.12, Python 3.12-3.14 and Django 4.2/5.2/6.0 classifiers, version 1.26.0. Drop test_suite/tests_require and the dead suite() in runtests.py, since setuptools 72 removed 'python setup.py test' - which the Makefile and publish workflow both still called. Add botocore to install_requires; sync.py imports it unconditionally but it was only declared in requirements.txt.

- CI: new tests.yml matrix over the supported combinations; publish workflow onto Python 3.14, pip install -e ., current action versions.

- MANIFEST.in: global-exclude/prune __pycache__, so the sdist stops shipping .pyc files.