### PR TITLE
Add a member to a project's team (#4814)

### DIFF
--- a/djconnectwise/api.py
+++ b/djconnectwise/api.py
@@ -1488,6 +1488,11 @@ class ProjectAPIClient(TicketAPIMixin, ConnectWiseAPIClient):
                                    should_page=True,
                                    *args, **kwargs)
 
+    def create_project_team_member(self, project_id, fields):
+        endpoint_url = '{}{}/{}'.format(self.ENDPOINT_PROJECTS, project_id,
+                                        self.ENDPOINT_PROJECT_TEAM_MEMBERS)
+        return self.create(endpoint_url, fields)
+
     def create_project(self, fields):
         return self.create(self.ENDPOINT_PROJECTS, fields)
 

--- a/djconnectwise/sync.py
+++ b/djconnectwise/sync.py
@@ -2633,6 +2633,27 @@ class ProjectTeamMemberSynchronizer(ChildFetchRecordsMixin, Synchronizer):
         'projectRole': (models.ProjectRole, 'project_role')
     }
 
+    API_FIELD_NAMES = {
+        'member': 'member',
+        'work_role': 'workRole',
+        'project_role': 'projectRole',
+    }
+
+    def create(self, project, fields, **kwargs):
+        """
+        Add a member to a project's team.
+
+        The project is in the endpoint URL, so it isn't part of the body.
+        """
+        client = self.client_class(
+            api_public_key=kwargs.get('api_public_key'),
+            api_private_key=kwargs.get('api_private_key')
+        )
+        api_fields = self._translate_fields_to_api_format(fields)
+        new_record = client.create_project_team_member(project.id, api_fields)
+
+        return self.update_or_create_instance(new_record)
+
     def _assign_field_data(self, instance, json_data):
         instance.id = json_data.get('id')
         start_date = json_data.get('startDate')
@@ -2662,6 +2683,9 @@ class ProjectTeamMemberSynchronizer(ChildFetchRecordsMixin, Synchronizer):
 
     @property
     def parent_object_ids(self):
+        if self.sync_single_id:
+            return [self.sync_single_id]
+
         return self.parent_model_class.objects.filter(
             status__closed_flag=False).order_by(
             self.lookup_key).values_list(self.lookup_key, flat=True)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = open('README.md').read()
 
-VERSION = (1, 27, 0)
+VERSION = (1, 28, 0)
 
 project_version = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
Adds the write side of ConnectWise project team members, for TopLeft #4814.

- `ProjectAPIClient.create_project_team_member` — `POST project/projects/{id}/teamMembers/`. The project is in the URL, so the body is just `{'member': {'id': N}, 'projectRole': {'id': N}}`.
- `ProjectTeamMemberSynchronizer.create` — posts and persists what comes back.
- `parent_object_ids` dropped the `sync_single_id` branch it inherits from `ChildFetchRecordsMixin`, so a callback sync of one project's team fetched every open project instead. Fixed.

### Deployment note

The ConnectWise API member's security role needs **Add** on **Project Teams**. Without it the POST returns `403 "You do not have security permission to perform this action."` — verified against staging both before and after granting it.

Verified end to end against the staging tenant: create, delete, and a single-project reconcile that prunes correctly.